### PR TITLE
Fix crash when reading large directories with truncated BLE responses

### DIFF
--- a/app.js
+++ b/app.js
@@ -236,6 +236,8 @@ class PixlToolsClient {
     const c = new Cursor(r.payload);
     const entries = [];
     while (c.remaining() >= 8) {
+      const nameLen = c.bytes[c.offset] | (c.bytes[c.offset + 1] << 8);
+      if (c.remaining() < 2 + nameLen + 4 + 1 + 1) break;
       const name = c.string();
       const size = c.u32();
       const type = c.u8() === 1 ? "DIR" : "FILE";
@@ -251,12 +253,12 @@ class PixlToolsClient {
           pos += 1;
           if (tlvType === 1) {
             // Notes: [len][...utf8...] — skip
-            if (pos >= metaEnd) break;
+            if (pos >= metaEnd || pos >= c.bytes.length) break;
             const len = c.bytes[pos]; pos += 1;
             pos += len;
           } else if (tlvType === 2) {
             // Flags: [flags_byte] — no length prefix
-            if (pos >= metaEnd) break;
+            if (pos >= metaEnd || pos >= c.bytes.length) break;
             meta.flags = c.bytes[pos]; pos += 1;
           } else if (tlvType === 3) {
             // NFC Tag ID: [head u32 LE][tail u32 LE] — no length prefix

--- a/app.js
+++ b/app.js
@@ -235,7 +235,7 @@ class PixlToolsClient {
     if (r.status !== 0) return { ok: false, error: this._vfsError(r.status), data: null };
     const c = new Cursor(r.payload);
     const entries = [];
-    while (c.remaining() >= 8) {
+    while (c.remaining() >= 8) { // 8 = 2 (name_len u16) + 4 (size u32) + 1 (type) + 1 (meta_size)
       const nameLen = c.bytes[c.offset] | (c.bytes[c.offset + 1] << 8);
       if (c.remaining() < 2 + nameLen + 4 + 1 + 1) break;
       const name = c.string();

--- a/app.js
+++ b/app.js
@@ -235,7 +235,7 @@ class PixlToolsClient {
     if (r.status !== 0) return { ok: false, error: this._vfsError(r.status), data: null };
     const c = new Cursor(r.payload);
     const entries = [];
-    while (c.remaining() > 0) {
+    while (c.remaining() >= 8) {
       const name = c.string();
       const size = c.u32();
       const type = c.u8() === 1 ? "DIR" : "FILE";
@@ -260,7 +260,7 @@ class PixlToolsClient {
             meta.flags = c.bytes[pos]; pos += 1;
           } else if (tlvType === 3) {
             // NFC Tag ID: [head u32 LE][tail u32 LE] — no length prefix
-            if (pos + 8 > metaEnd) break;
+            if (pos + 8 > metaEnd || pos + 8 > c.bytes.length) break;
             const mv = new DataView(c.bytes.buffer, c.bytes.byteOffset + pos, 8);
             meta.nfcTagHead = mv.getUint32(0, true);
             meta.nfcTagTail = mv.getUint32(4, true);
@@ -269,7 +269,7 @@ class PixlToolsClient {
             break; // unknown type, length unknown — cannot continue
           }
         }
-        c.offset = metaEnd;
+        c.offset = Math.min(metaEnd, c.bytes.length);
       }
       entries.push({ name, size, type, meta });
     }


### PR DESCRIPTION
When the firmware truncates a large directory listing mid-entry (due to BLE packet loss or a TX buffer limit), the response payload ends with partial bytes from the next incomplete entry. The old loop guard `remaining() > 0` would attempt to parse those trailing bytes, advance the cursor past the buffer end via Cursor.take(), and then crash with "Start offset X is outside the bounds of the buffer" from DataView — discarding all successfully-parsed entries.

Three targeted fixes in readFolder():
- Loop guard changed to `remaining() >= 8` (minimum bytes for any valid entry: 2 name_len + 4 size + 1 type + 1 meta_size). The loop now exits cleanly before touching any incomplete trailing bytes.
- NFC Tag ID DataView guard extended with `pos + 8 > c.bytes.length` so it also catches the case where metaEnd itself extends beyond the actual buffer (firmware-reported metaSize larger than remaining data).
- Cursor advancement uses `Math.min(metaEnd, c.bytes.length)` so that a truncated metadata block doesn't push c.offset past the buffer end, which would make remaining() go negative and leave the loop in an undefined state.

All complete entries in the response are now returned and displayed; only data the firmware never sent (the truncated tail) is absent.

Fixes: https://github.com/tasken/MochiNest/issues/1