### PR TITLE
Fix corrupted last entry in truncated BLE dir listings; warn on long …

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,7 @@ const MAX_FILE_NAME_BYTES = 47;
 const MAX_FILE_PATH_BYTES = 65;
 const MAX_FOLDER_PATH_BYTES = 57;
 const LARGE_DIR_THRESHOLD = 80;
-const LONG_FILENAME_THRESHOLD = 15;
+const LONG_FILENAME_BYTES = 15;
 const LARGE_BATCH_THRESHOLD = 200;
 const PIXL_RELEASES_URL = "https://github.com/solosky/pixl.js/releases";
 const PIXL_LATEST_API = "https://api.github.com/repos/solosky/pixl.js/releases/latest";
@@ -1174,8 +1174,8 @@ function renderFileTable() {
     const isPanelActive = state.drawerEntry && state.drawerEntry.name === entry.name;
     const isSelected = state.selectedNames.has(entry.name);
 
-    const warnIcon = state.truncated && utf8Length(entry.name) > LONG_FILENAME_THRESHOLD
-      ? `<span class="ms-sm warn-icon" title="Long filename contributes to BLE transfer limit">warning</span> `
+    const warnIcon = state.truncated && utf8Length(entry.name) > LONG_FILENAME_BYTES
+      ? `<span class="ms-sm warn-icon" title="Filename exceeds ${LONG_FILENAME_BYTES} bytes and contributes to BLE transfer limit">warning</span> `
       : "";
     const nameCell = isDir
       ? `<td class="cell-name folder">${warnIcon}<span class="ms-sm">folder</span> ${escapeHtml(entry.name)}</td>`

--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const MAX_FILE_NAME_BYTES = 47;
 const MAX_FILE_PATH_BYTES = 65;
 const MAX_FOLDER_PATH_BYTES = 57;
 const LARGE_DIR_THRESHOLD = 80;
+const LONG_FILENAME_THRESHOLD = 15;
 const LARGE_BATCH_THRESHOLD = 200;
 const PIXL_RELEASES_URL = "https://github.com/solosky/pixl.js/releases";
 const PIXL_LATEST_API = "https://api.github.com/repos/solosky/pixl.js/releases/latest";
@@ -246,6 +247,7 @@ class PixlToolsClient {
       const size = c.u32();
       const type = c.u8() === 1 ? "DIR" : "FILE";
       const metaSize = c.u8();
+      if (c.remaining() < metaSize) break;
       const meta = { flags: 0, nfcTagHead: null, nfcTagTail: null };
       if (metaSize > 0) {
         const metaStart = c.offset;
@@ -702,6 +704,7 @@ const state = {
   abortController: null,
   transferSpeed: "",
   folderCache: new Map(),
+  truncated: false,
 };
 
 // === Protocol Log ===
@@ -1058,8 +1061,12 @@ async function browseFolder(path) {
   if (!state.client || state.connState !== "connected") return;
 
   // Check cache first
-  let entries = state.folderCache.get(path);
-  if (!entries) {
+  let entries, truncated = false;
+  const cached = state.folderCache.get(path);
+  if (cached) {
+    entries = cached.entries;
+    truncated = cached.truncated;
+  } else {
     try {
       const res = await state.client.readFolder(path);
       if (!res.ok) {
@@ -1067,11 +1074,12 @@ async function browseFolder(path) {
         return;
       }
       entries = sortEntries(res.data);
-      state.folderCache.set(path, entries);
+      truncated = res.truncated || false;
+      state.folderCache.set(path, { entries, truncated });
       for (const e of entries) {
         if (e.type === "DIR") state.client.createdFolders.add(joinChildPath(path, e.name));
       }
-      if (res.truncated) {
+      if (truncated) {
         showToast("WARN:Directory listing may be incomplete, some entries could not be received over BLE");
         log(`Warning: directory listing for ${path} was truncated (${entries.length} entries received)`, "err");
       } else if (entries.length >= LARGE_DIR_THRESHOLD) {
@@ -1086,6 +1094,7 @@ async function browseFolder(path) {
 
   state.currentPath = path;
   state.entries = entries;
+  state.truncated = truncated;
   state.selectedNames.clear();
   renderBreadcrumb(path);
   renderFileTable();
@@ -1164,9 +1173,12 @@ function renderFileTable() {
     const isPanelActive = state.drawerEntry && state.drawerEntry.name === entry.name;
     const isSelected = state.selectedNames.has(entry.name);
 
+    const warnIcon = state.truncated && entry.name.length > LONG_FILENAME_THRESHOLD
+      ? `<span class="ms-sm warn-icon" title="Long filename contributes to BLE transfer limit">warning</span> `
+      : "";
     const nameCell = isDir
-      ? `<td class="cell-name folder"><span class="ms-sm">folder</span> ${escapeHtml(entry.name)}</td>`
-      : `<td class="cell-name"><span class="ms-sm">insert_drive_file</span> ${escapeHtml(entry.name)}</td>`;
+      ? `<td class="cell-name folder">${warnIcon}<span class="ms-sm">folder</span> ${escapeHtml(entry.name)}</td>`
+      : `<td class="cell-name">${warnIcon}<span class="ms-sm">insert_drive_file</span> ${escapeHtml(entry.name)}</td>`;
 
     const classes = [isPanelActive ? "panel-active" : "", isSelected ? "selected" : ""].filter(Boolean).join(" ");
     rows.push(
@@ -2017,7 +2029,7 @@ function checkUploadPlanWarnings(plan) {
   // Add cached entry counts for existing items
   for (const [dir, planned] of perDir) {
     const cached = state.folderCache.get(dir);
-    const existing = cached ? cached.length : 0;
+    const existing = cached ? cached.entries.length : 0;
     const total = planned + existing;
     if (total >= LARGE_DIR_THRESHOLD) {
       warnings.push(`${dir} will have ${total} items (${existing} existing + ${planned} new), which may cause slow or unreliable BLE directory reads`);

--- a/app.js
+++ b/app.js
@@ -240,6 +240,7 @@ class PixlToolsClient {
     if (r.status !== 0) return { ok: false, error: this._vfsError(r.status), data: null };
     const c = new Cursor(r.payload);
     const entries = [];
+    let truncated = false;
     while (c.remaining() >= 8) { // 8 = 2 (name_len u16) + 4 (size u32) + 1 (type) + 1 (meta_size)
       const nameLen = c.bytes[c.offset] | (c.bytes[c.offset + 1] << 8);
       if (c.remaining() < 2 + nameLen + 4 + 1 + 1) break;
@@ -247,7 +248,7 @@ class PixlToolsClient {
       const size = c.u32();
       const type = c.u8() === 1 ? "DIR" : "FILE";
       const metaSize = c.u8();
-      if (c.remaining() < metaSize) break;
+      if (c.remaining() < metaSize) { truncated = true; break; }
       const meta = { flags: 0, nfcTagHead: null, nfcTagTail: null };
       if (metaSize > 0) {
         const metaStart = c.offset;
@@ -281,7 +282,7 @@ class PixlToolsClient {
       }
       entries.push({ name, size, type, meta });
     }
-    const truncated = c.remaining() > 0;
+    truncated = truncated || c.remaining() > 0;
     return { ok: true, error: null, data: entries, truncated };
   }
 
@@ -1173,7 +1174,7 @@ function renderFileTable() {
     const isPanelActive = state.drawerEntry && state.drawerEntry.name === entry.name;
     const isSelected = state.selectedNames.has(entry.name);
 
-    const warnIcon = state.truncated && entry.name.length > LONG_FILENAME_THRESHOLD
+    const warnIcon = state.truncated && utf8Length(entry.name) > LONG_FILENAME_THRESHOLD
       ? `<span class="ms-sm warn-icon" title="Long filename contributes to BLE transfer limit">warning</span> `
       : "";
     const nameCell = isDir

--- a/styles.css
+++ b/styles.css
@@ -622,6 +622,7 @@
 
   .cell-name.folder { color: #7878cc; }
   .cell-name.folder:hover { text-decoration: underline; }
+  .warn-icon { color: oklch(0.62 0.16 70); }
 
   .cell-size {
     font-family: "IBM Plex Mono", monospace;


### PR DESCRIPTION
…filenames

- Drop entries whose declared metadata exceeds remaining buffer bytes (prevents "051 - O 054 -" / 1622 MB ghost entry when firmware TX cap is hit mid-metadata)
- Store truncated flag in folderCache alongside entries so re-visits preserve the warning state
- Show amber warning icon next to entries with names > 15 chars when the listing was truncated, to hint at the filename-length / BLE-buffer trade-off